### PR TITLE
MigrationFactory Stores the Supplied Assembly

### DIFF
--- a/source/LiteMigrator.Tests/SqliteTests/RawLocalDatabaseTest.cs
+++ b/source/LiteMigrator.Tests/SqliteTests/RawLocalDatabaseTest.cs
@@ -16,7 +16,7 @@ namespace LiteMigrator.SystemTests.Specs.SqliteTests
   [TestClass]
   public class RawLocalDatabaseTest
   {
-    private readonly string _dbPath = ":memory:"; // @"C:\temp\test.db"
+    private readonly string _dbPath = ":memory:";
     private SQLite.SQLiteAsyncConnection _db;
 
     public RawLocalDatabaseTest()

--- a/source/LiteMigrator/Engines/SqlcipherEngine.cs
+++ b/source/LiteMigrator/Engines/SqlcipherEngine.cs
@@ -12,7 +12,7 @@ namespace LiteMigrator.Engines;
 
 internal class SqlcipherEngine : IEngine
 {
-  public string LastErrorMessage { get; private set; }
+  public string LastErrorMessage { get; private set; } = string.Empty;
 
   public bool MigrateUp()
   {

--- a/source/LiteMigrator/Engines/SqlitePclEngine.cs
+++ b/source/LiteMigrator/Engines/SqlitePclEngine.cs
@@ -23,7 +23,7 @@ internal class SqlitePclEngine : IEngine
   ////  _migrationFactory = migrationFactory;
   ////}
 
-  public string LastErrorMessage { get; private set; }
+  public string LastErrorMessage { get; private set; } = string.Empty;
 
   /// <summary>Execute all missing migrations.</summary>
   /// <returns>Pass/Fail.</returns>

--- a/source/LiteMigrator/Factory/MigrationFactory.cs
+++ b/source/LiteMigrator/Factory/MigrationFactory.cs
@@ -22,9 +22,19 @@ public class MigrationFactory
   public MigrationFactory()
   {
     BaseNamespace = GetType().Namespace;
-    BaseAssemblyFile = string.Empty;
+    BaseAssembly = null;
+    //// BaseAssemblyFile = string.Empty;
   }
 
+  public MigrationFactory(string baseNamespace, Assembly baseAssembly)
+  {
+    BaseAssembly = baseAssembly;
+    BaseNamespace = baseNamespace;
+  }
+
+  public Assembly BaseAssembly { get; set; }
+
+  /*
   public MigrationFactory(string baseNamespace, string baseAssemblyFile = "")
   {
     BaseNamespace = baseNamespace;
@@ -55,6 +65,7 @@ public class MigrationFactory
   }
 
   public string BaseAssemblyFile { get; set; }
+  */
 
   public string BaseNamespace { get; set; }
 
@@ -79,12 +90,11 @@ public class MigrationFactory
     string result = string.Empty;
     try
     {
-      var assembly = BaseAssembly; //// Assembly.GetExecutingAssembly();
-      using (Stream stream = assembly.GetManifestResourceStream(resourcePath))
-      using (StreamReader reader = new StreamReader(stream))
-      {
-        result = reader.ReadToEnd();
-      }
+      var assembly = BaseAssembly is not null ? BaseAssembly : Assembly.GetExecutingAssembly();
+
+      using Stream stream = assembly.GetManifestResourceStream(resourcePath);
+      using StreamReader reader = new(stream);
+      result = reader.ReadToEnd();
     }
     catch (Exception ex)
     {
@@ -111,7 +121,7 @@ public class MigrationFactory
     string resName = string.Empty;
     string fileName = string.Empty;
 
-    var assembly = BaseAssembly; //// Assembly.GetExecutingAssembly();
+    var assembly = BaseAssembly;
     var items = assembly.GetManifestResourceNames()
                         .Where(name => name.StartsWith(BaseNamespace));
 
@@ -150,9 +160,11 @@ public class MigrationFactory
 
     try
     {
-      item = BaseAssembly.GetManifestResourceNames()
-                         .Where(name => name.StartsWith(BaseNamespace))
-                         .Single(x => x.Contains(containingTitle));
+      Assembly assembly = BaseAssembly is not null ? BaseAssembly : Assembly.GetExecutingAssembly();
+
+      item = assembly.GetManifestResourceNames()
+                     .Where(name => name.StartsWith(BaseNamespace))
+                     .Single(x => x.Contains(containingTitle));
     }
     catch (Exception ex)
     {
@@ -167,13 +179,7 @@ public class MigrationFactory
 
   public List<string> GetResources()
   {
-    // All loaded assemblies
-    //// var assm1 = AppDomain.CurrentDomain.GetAssemblies();
-
-    // Old method:
-    //// var assembly = Assembly.GetExecutingAssembly();
-
-    var assembly = BaseAssembly;
+    var assembly = BaseAssembly is not null ? BaseAssembly : Assembly.GetExecutingAssembly();
 
     var items = assembly.GetManifestResourceNames()
                         .Where(name => name.StartsWith(BaseNamespace))
@@ -188,10 +194,18 @@ public class MigrationFactory
   /// <remarks>Rename to, GetMigrations().</remarks>
   public SortedDictionary<long, IMigration> GetSortedMigrations()
   {
-    //// var assembly = BaseAssembly; //// Assembly.GetExecutingAssembly();
+    var assembly = BaseAssembly is not null ? BaseAssembly : Assembly.GetExecutingAssembly();
+
+    var resources = assembly.GetManifestResourceNames();
+    var items = resources
+      .Where(name => name.StartsWith(BaseNamespace) && name.EndsWith(".sql"));
+
+    /*
+    var assembly = BaseAssembly; //// Assembly.GetExecutingAssembly();
     var items = BaseAssembly
       .GetManifestResourceNames()
       .Where(name => name.StartsWith(BaseNamespace) && name.EndsWith(".sql"));
+    */
 
     // TODO: Need to check if error and report why
     // I.E.

--- a/source/LiteMigrator/LiteMigration.cs
+++ b/source/LiteMigrator/LiteMigration.cs
@@ -82,7 +82,8 @@ public partial class LiteMigration : IDisposable
     // Initialize().Wait();
     Migrations = new()
     {
-      BaseAssemblyFile = baseAssembly is null ? string.Empty : baseAssembly.Location,
+      // BaseAssemblyFile = baseAssembly is null ? string.Empty : baseAssembly.Location,
+      BaseAssembly = baseAssembly,
       BaseNamespace = baseNamespace,
     };
 
@@ -161,22 +162,13 @@ public partial class LiteMigration : IDisposable
   public DatabaseType DatabaseType { get; set; }
 
   /// <summary>Gets a value indicating whether is connected to the database.</summary>
-  public bool IsConnected
-  {
-    get
-    {
-      if (Connection is null)
-        return false;
-      else
-        return true;
-    }
-  }
+  public bool IsConnected => Connection is not null;
 
   /// <summary>Gets the last known error.</summary>
   public string LastError { get; private set; }
 
   /// <summary>Gets the last known error.</summary>
-  public Exception? LastException { get; private set; }
+  public Exception LastException { get; private set; }
 
   public MigrationFactory Migrations { get; private set; }
 
@@ -188,10 +180,12 @@ public partial class LiteMigration : IDisposable
     if (IsConnected)
     {
       // Disconnect so we can reconnect
+      _connection.CloseAsync().Wait();
     }
 
     try
     {
+      // Use default flags: openFlags = SQLiteOpenFlags.ReadWrite | SQLiteOpenFlags.Create | SQLiteOpenFlags.FullMutex
       _connection = new SQLiteAsyncConnection(DatabasePath);
       return true;
     }


### PR DESCRIPTION
## Details

Store the supplied assembly object and not the string of the library to load. This addresses Android's ability to load the assembly where the scripts are located on .NET MAUI

## Linked To Issue/Feature

* #25 
