### PR TITLE
Rename main class to Migration

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,13 @@
 # LiteMigrator Change Log
 
+## v0.9.0
+
+Breaking Changes:
+
+* [NEW] Renamed class `LiteMigration` to `Migrator`
+* [FIX] BaseAssembly object is used instead of BaseAssemblyFile (string)
+  * This fixes loading migrations on Android
+
 ## v0.8.0
 
 Constructor and namespace cleanup.

--- a/source/LiteMigrator.Tests/Specs/FactoryTests.cs
+++ b/source/LiteMigrator.Tests/Specs/FactoryTests.cs
@@ -23,7 +23,7 @@ public class LiteMigratorFactoryTests : BaseTest
   public void GetMigrationScriptByNameTest()
   {
     // Arrange
-    var migrator = new LiteMigration(InMemoryDatabasePath, BaseNamespace, Assembly.GetExecutingAssembly());
+    var migrator = new Migrator(InMemoryDatabasePath, BaseNamespace, Assembly.GetExecutingAssembly());
 
     // Act
     string ns = migrator.Migrations.GetResourceNamed(ScriptName);
@@ -38,7 +38,7 @@ public class LiteMigratorFactoryTests : BaseTest
   [TestMethod]
   public void GetMigrationScriptTest()
   {
-    var migrator = new LiteMigration(InMemoryDatabasePath, BaseNamespace, Assembly.GetExecutingAssembly());
+    var migrator = new Migrator(InMemoryDatabasePath, BaseNamespace, Assembly.GetExecutingAssembly());
 
     // Sample: "MyProject.Client.Business.Migrations.201909150000-BaseDDL.sql"
     bool success = migrator.Migrations.GetMigrationScriptByName(ScriptFullName, out string? data);
@@ -51,7 +51,7 @@ public class LiteMigratorFactoryTests : BaseTest
   [TestMethod]
   public void GetMigrationScriptVerionTest()
   {
-    var migrator = new LiteMigration(InMemoryDatabasePath, BaseNamespace, Assembly.GetExecutingAssembly());
+    var migrator = new Migrator(InMemoryDatabasePath, BaseNamespace, Assembly.GetExecutingAssembly());
 
     var results = migrator.Migrations.GetMigrationScriptByVersion(ScriptRevision, out string? sql);
 
@@ -65,7 +65,7 @@ public class LiteMigratorFactoryTests : BaseTest
   public void GetResourceNamedTest()
   {
     // Arrange
-    var migrator = new LiteMigration(InMemoryDatabasePath, BaseNamespace, Assembly.GetExecutingAssembly());
+    var migrator = new Migrator(InMemoryDatabasePath, BaseNamespace, Assembly.GetExecutingAssembly());
 
     // Act
     string data = migrator.Migrations.GetResourceNamed(ScriptName);
@@ -79,7 +79,7 @@ public class LiteMigratorFactoryTests : BaseTest
   public void GetResourcesTests()
   {
     // Arrange
-    var migrator = new LiteMigration(InMemoryDatabasePath, BaseNamespace, Assembly.GetExecutingAssembly());
+    var migrator = new Migrator(InMemoryDatabasePath, BaseNamespace, Assembly.GetExecutingAssembly());
 
     // Act
     var items = migrator.Migrations.GetResources();
@@ -100,7 +100,7 @@ public class LiteMigratorFactoryTests : BaseTest
   {
     // Arrange
     long oldVer = 0;
-    var migrator = new LiteMigration(InMemoryDatabasePath, BaseNamespace, Assembly.GetExecutingAssembly());
+    var migrator = new Migrator(InMemoryDatabasePath, BaseNamespace, Assembly.GetExecutingAssembly());
 
     // Act
     var items = migrator.Migrations.GetSortedMigrations();
@@ -128,7 +128,7 @@ public class LiteMigratorFactoryTests : BaseTest
   {
     // Arrange
     long oldVer = 0;
-    var migrator = new LiteMigration(InMemoryDatabasePath, BaseNamespace, Assembly.GetExecutingAssembly());
+    var migrator = new Migrator(InMemoryDatabasePath, BaseNamespace, Assembly.GetExecutingAssembly());
 
     // Act
     var items = migrator.Migrations.GetSortedMigrations();

--- a/source/LiteMigrator.Tests/Specs/MigrateInFileTests.cs
+++ b/source/LiteMigrator.Tests/Specs/MigrateInFileTests.cs
@@ -44,7 +44,7 @@ public class MigratorInFileTests : BaseTest
   {
     DeleteDatabase();
 
-    var mig = new LiteMigration(TempDatabasePath, _baseNamespace, Assembly.GetExecutingAssembly());
+    var mig = new Migrator(TempDatabasePath, _baseNamespace, Assembly.GetExecutingAssembly());
 
     var allMigs = mig.Migrations.GetSortedMigrations();
     var missing = await mig.GetMissingMigrationsAsync();
@@ -71,7 +71,7 @@ public class MigratorInFileTests : BaseTest
     // returns sorted list of IMigration with namespace path to resource
     ClearVersionInfo();
 
-    var mig = new LiteMigration(TempDatabasePath, _baseNamespace, Assembly.GetExecutingAssembly());
+    var mig = new Migrator(TempDatabasePath, _baseNamespace, Assembly.GetExecutingAssembly());
 
     var allMigs = mig.Migrations.GetSortedMigrations();
     var missing = await mig.GetMissingMigrationsAsync();

--- a/source/LiteMigrator.Tests/Specs/MigrationInMemoryTests.cs
+++ b/source/LiteMigrator.Tests/Specs/MigrationInMemoryTests.cs
@@ -21,7 +21,7 @@ public sealed class MigrationInMemoryTests : BaseTest
   public async Task GetMigrationScriptsTestAsync()
   {
     // Initializes and performs migration.
-    var migrator = new LiteMigration(InMemoryDatabasePath, ScriptNamespace, Assembly.GetExecutingAssembly());
+    var migrator = new Migrator(InMemoryDatabasePath, ScriptNamespace, Assembly.GetExecutingAssembly());
 
     // Find available migration scripts and those not installed
     var allMigrations = migrator.Migrations.GetSortedMigrations();
@@ -35,7 +35,7 @@ public sealed class MigrationInMemoryTests : BaseTest
   [TestMethod]
   public async Task InstallMigrationsAsync()
   {
-    using (var migrator = new LiteMigration(InMemoryDatabasePath, ScriptNamespace, Assembly.GetExecutingAssembly()))
+    using (var migrator = new Migrator(InMemoryDatabasePath, ScriptNamespace, Assembly.GetExecutingAssembly()))
     {
       // Act
       bool isSuccess = await migrator.MigrateUpAsync();

--- a/source/LiteMigrator.Tests/Specs/VersionInfoTests.cs
+++ b/source/LiteMigrator.Tests/Specs/VersionInfoTests.cs
@@ -37,7 +37,7 @@ namespace LiteMigrator.SystemTests.Specs
       // Arrange
       ClearVersionInfo();
 
-      var mig = new LiteMigration(TempDatabasePath, string.Empty);
+      var mig = new Migrator(TempDatabasePath, string.Empty);
 
       // Act
       SQLiteAsyncConnection db = new SQLiteAsyncConnection(TempDatabasePath);
@@ -55,7 +55,7 @@ namespace LiteMigrator.SystemTests.Specs
     [TestMethod]
     public async Task CanCreateVersionInfoTable_InFile_TestAsync()
     {
-      using (var mig = new LiteMigration(TempDatabasePath, string.Empty))
+      using (var mig = new Migrator(TempDatabasePath, string.Empty))
       {
         var columnInfo = await mig.Connection.GetTableInfoAsync(nameof(VersionInfo));
 
@@ -66,7 +66,7 @@ namespace LiteMigrator.SystemTests.Specs
     [TestMethod]
     public async Task CanCreateVersionInfoTable_InMemory_TestAsync()
     {
-      using (var mig = new LiteMigration())
+      using (var mig = new Migrator())
       {
         var columnInfo = await mig.Connection.GetTableInfoAsync(nameof(VersionInfo));
 
@@ -79,7 +79,7 @@ namespace LiteMigrator.SystemTests.Specs
     {
       // Arrange
       ClearVersionInfo();
-      var mig = new LiteMigration(TempDatabasePath, string.Empty);
+      var mig = new Migrator(TempDatabasePath, string.Empty);
 
       SQLiteAsyncConnection db = new SQLiteAsyncConnection(TempDatabasePath);
       await AddVersionInfoForTestsAsync(db, mig);
@@ -95,7 +95,7 @@ namespace LiteMigrator.SystemTests.Specs
       Assert.IsTrue(list.ContainsKey(202512312359), "Missing Migration, 'LTS update'");
     }
 
-    private async Task AddVersionInfoForTestsAsync(SQLiteAsyncConnection db, LiteMigration mig)
+    private async Task AddVersionInfoForTestsAsync(SQLiteAsyncConnection db, Migrator mig)
     {
       await mig.RegisterVersionAsync(db, new Migration(199609081025, "When it all began"));
       await mig.RegisterVersionAsync(db, new Migration(201912312359, "Some update"));

--- a/source/LiteMigrator/Factory/MigrationFactory.cs
+++ b/source/LiteMigrator/Factory/MigrationFactory.cs
@@ -90,7 +90,7 @@ public class MigrationFactory
     string result = string.Empty;
     try
     {
-      var assembly = BaseAssembly is not null ? BaseAssembly : Assembly.GetExecutingAssembly();
+      var assembly = BaseAssembly is not null ? BaseAssembly : Assembly.GetCallingAssembly();
 
       using Stream stream = assembly.GetManifestResourceStream(resourcePath);
       using StreamReader reader = new(stream);
@@ -160,7 +160,7 @@ public class MigrationFactory
 
     try
     {
-      Assembly assembly = BaseAssembly is not null ? BaseAssembly : Assembly.GetExecutingAssembly();
+      Assembly assembly = BaseAssembly is not null ? BaseAssembly : Assembly.GetCallingAssembly();
 
       item = assembly.GetManifestResourceNames()
                      .Where(name => name.StartsWith(BaseNamespace))
@@ -179,7 +179,7 @@ public class MigrationFactory
 
   public List<string> GetResources()
   {
-    var assembly = BaseAssembly is not null ? BaseAssembly : Assembly.GetExecutingAssembly();
+    var assembly = BaseAssembly is not null ? BaseAssembly : Assembly.GetCallingAssembly();
 
     var items = assembly.GetManifestResourceNames()
                         .Where(name => name.StartsWith(BaseNamespace))
@@ -194,7 +194,7 @@ public class MigrationFactory
   /// <remarks>Rename to, GetMigrations().</remarks>
   public SortedDictionary<long, IMigration> GetSortedMigrations()
   {
-    var assembly = BaseAssembly is not null ? BaseAssembly : Assembly.GetExecutingAssembly();
+    var assembly = BaseAssembly is not null ? BaseAssembly : Assembly.GetCallingAssembly();
 
     var resources = assembly.GetManifestResourceNames();
     var items = resources

--- a/source/LiteMigrator/Migrator.Scripts.cs
+++ b/source/LiteMigrator/Migrator.Scripts.cs
@@ -1,7 +1,7 @@
 /* Copyright Xeno Innovations, Inc. 2019
  * Date:    2019-9-15
  * Author:  Damian Suess
- * File:    LiteMigrator.Scripts.cs
+ * File:    Migrator.Scripts.cs
  * Description:
  *  Simple SQL Migration Scripts Engine
  */
@@ -14,7 +14,7 @@ using LiteMigrator.Factory;
 namespace LiteMigrator;
 
 /// <summary>LiteMigration, migration scripts.</summary>
-public partial class LiteMigration
+public partial class Migrator
 {
   /*
   /// <summary>Executes a single migration script.</summary>

--- a/source/LiteMigrator/Migrator.Version.cs
+++ b/source/LiteMigrator/Migrator.Version.cs
@@ -1,7 +1,7 @@
 /* Copyright Xeno Innovations, Inc. 2019
  * Date:    2019-9-15
  * Author:  Damian Suess
- * File:    LiteMigrator.Version.cs
+ * File:    Migrator.Version.cs
  * Description:
  *  Simple SQL Migration Versioning Engine
  */
@@ -16,7 +16,7 @@ using SQLite;
 namespace LiteMigrator;
 
 /// <summary>Version Factory of LiteMigration.</summary>
-public partial class LiteMigration
+public partial class Migrator
 {
   /// <summary>Gets or sets the list of applied migrations.</summary>
   /// <value>The list of applied migrations.</value>

--- a/source/LiteMigrator/Migrator.cs
+++ b/source/LiteMigrator/Migrator.cs
@@ -1,7 +1,7 @@
 /* Copyright Xeno Innovations, Inc. 2019
  * Date:    2019-9-15
  * Author:  Damian Suess
- * File:    LiteMigrator.cs
+ * File:    Migrator.cs
  * Description:
  *  Simple SQL Migration Engine base class and constructors
  */
@@ -19,7 +19,7 @@ namespace LiteMigrator;
 ///  2. Refactor order of constructor properties (making all of them sequential).
 ///  3. Make disposable, exposing the SQLite DB object. - In-Memory tests will fail once connection is closed.
 /// </remarks>
-public partial class LiteMigration : IDisposable
+public partial class Migrator : IDisposable
 {
   private const string InMemoryDatabase = ":memory:";
 
@@ -33,10 +33,10 @@ public partial class LiteMigration : IDisposable
   */
 
   /// <summary>
-  ///   Initializes a new instance of the <see cref="LiteMigration"/> class using an in-memory database.
+  ///   Initializes a new instance of the <see cref="Migrator"/> class using an in-memory database.
   ///   Assumes the current namespace, and using generic SQLite.
   /// </summary>
-  public LiteMigration()
+  public Migrator()
     : this(InMemoryDatabase, string.Empty, null)
   {
     // Set to current namespace, it's a something
@@ -45,34 +45,34 @@ public partial class LiteMigration : IDisposable
   }
 
   /// <summary>
-  ///   Initializes a new instance of the <see cref="LiteMigration"/> class.
+  ///   Initializes a new instance of the <see cref="Migrator"/> class.
   ///   Assumes no namespace filter and executing assembly contains the scripts.
   /// </summary>
   /// <param name="databasePath">Path to database.</param>
-  public LiteMigration(string databasePath)
+  public Migrator(string databasePath)
     : this(databasePath, string.Empty, null)
   {
   }
 
   /// <summary>
-  ///   Initializes a new instance of the <see cref="LiteMigration"/> class.
+  ///   Initializes a new instance of the <see cref="Migrator"/> class.
   ///   Assumes executing assembly contains the scripts.
   /// </summary>
   /// <param name="databasePath">Path to database.</param>
   /// <param name="baseNamespace">Assembly path to migration scripts.</param>
-  public LiteMigration(string databasePath, string baseNamespace)
+  public Migrator(string databasePath, string baseNamespace)
     : this(databasePath, baseNamespace, null)
   {
   }
 
   /// <summary>
-  ///   Initializes a new instance of the <see cref="LiteMigration"/> class.
+  ///   Initializes a new instance of the <see cref="Migrator"/> class.
   /// </summary>
   /// <param name="databasePath">Path to the SQLite database.</param>
   /// <param name="baseNamespace">Namespace to scripts.</param>
   /// <param name="databaseType">Type of database connection.</param>
   /// <param name="baseAssembly">Migration's base assembly name.</param>
-  public LiteMigration(string databasePath, string baseNamespace, Assembly baseAssembly = null)
+  public Migrator(string databasePath, string baseNamespace, Assembly baseAssembly = null)
   {
     ////RevisionTable = nameof(VersionInfo);  // FUTURE
     // Set to current namespace, it's a something


### PR DESCRIPTION
## Details

**BREAKING CHANGE**

Renamed the main class from `LiteMigration` to `Migrator`. The latter name does not conflict with the purpose of the class. Whereas the name "migration" could be considered as a single entity; it is not.

* #24 