### PR TITLE
Default Assembly in CTR to use Calling Assembly

### DIFF
--- a/source/LiteMigrator.Tests/Specs/FactoryTests.cs
+++ b/source/LiteMigrator.Tests/Specs/FactoryTests.cs
@@ -21,6 +21,28 @@ public class LiteMigratorFactoryTests : BaseTest
   [TestMethod]
   [DataRow(false)]
   [DataRow(true)]
+  public void MissingBaseNamespaceFails_GetMigrationScriptByNameTest(bool useExecutingAssm)
+  {
+    Assembly? assm = useExecutingAssm ? Assembly.GetExecutingAssembly() : null;
+
+    // Arrange
+    using var migrator = new Migrator(InMemoryDatabasePath, string.Empty, assm);
+
+    // Act
+    string ns = migrator.Migrations.GetResourceNamed(ScriptName);
+    migrator.Migrations.GetMigrationScriptByName(ns, out string? sql);
+
+    // Assert
+    Assert.IsNotNull(sql);
+    Assert.IsFalse(string.IsNullOrEmpty(ns));
+
+    // Fails to get SQL file because we don't know resource path from file name.
+    Assert.IsTrue(string.IsNullOrEmpty(sql));
+  }
+
+  [TestMethod]
+  [DataRow(false)]
+  [DataRow(true)]
   public void GetMigrationScriptByNameTest(bool useExecutingAssm)
   {
     Assembly? assm = useExecutingAssm ? Assembly.GetExecutingAssembly() : null;

--- a/source/LiteMigrator.Tests/Specs/FactoryTests.cs
+++ b/source/LiteMigrator.Tests/Specs/FactoryTests.cs
@@ -26,7 +26,7 @@ public class LiteMigratorFactoryTests : BaseTest
     Assembly? assm = useExecutingAssm ? Assembly.GetExecutingAssembly() : null;
 
     // Arrange
-    var migrator = new Migrator(InMemoryDatabasePath, BaseNamespace, assm);
+    using var migrator = new Migrator(InMemoryDatabasePath, BaseNamespace, assm);
 
     // Act
     string ns = migrator.Migrations.GetResourceNamed(ScriptName);
@@ -45,7 +45,7 @@ public class LiteMigratorFactoryTests : BaseTest
   {
     Assembly? assm = useExecutingAssm ? Assembly.GetExecutingAssembly() : null;
 
-    var migrator = new Migrator(InMemoryDatabasePath, BaseNamespace, assm);
+    using var migrator = new Migrator(InMemoryDatabasePath, BaseNamespace, assm);
 
     // Sample: "MyProject.Client.Business.Migrations.201909150000-BaseDDL.sql"
     bool success = migrator.Migrations.GetMigrationScriptByName(ScriptFullName, out string? data);
@@ -62,7 +62,7 @@ public class LiteMigratorFactoryTests : BaseTest
   {
     Assembly? assm = useExecutingAssm ? Assembly.GetExecutingAssembly() : null;
 
-    var migrator = new Migrator(InMemoryDatabasePath, BaseNamespace, Assembly.GetExecutingAssembly());
+    using var migrator = new Migrator(InMemoryDatabasePath, BaseNamespace, assm);
 
     var results = migrator.Migrations.GetMigrationScriptByVersion(ScriptRevision, out string? sql);
 
@@ -80,7 +80,7 @@ public class LiteMigratorFactoryTests : BaseTest
     Assembly? assm = useExecutingAssm ? Assembly.GetExecutingAssembly() : null;
 
     // Arrange
-    var migrator = new Migrator(InMemoryDatabasePath, BaseNamespace, Assembly.GetExecutingAssembly());
+    using var migrator = new Migrator(InMemoryDatabasePath, BaseNamespace, assm);
 
     // Act
     string data = migrator.Migrations.GetResourceNamed(ScriptName);
@@ -98,7 +98,7 @@ public class LiteMigratorFactoryTests : BaseTest
     Assembly? assm = useExecutingAssm ? Assembly.GetExecutingAssembly() : null;
 
     // Arrange
-    var migrator = new Migrator(InMemoryDatabasePath, BaseNamespace, Assembly.GetExecutingAssembly());
+    using var migrator = new Migrator(InMemoryDatabasePath, BaseNamespace, assm);
 
     // Act
     var items = migrator.Migrations.GetResources();
@@ -123,7 +123,7 @@ public class LiteMigratorFactoryTests : BaseTest
 
     // Arrange
     long oldVer = 0;
-    var migrator = new Migrator(InMemoryDatabasePath, BaseNamespace, Assembly.GetExecutingAssembly());
+    using var migrator = new Migrator(InMemoryDatabasePath, BaseNamespace, assm);
 
     // Act
     var items = migrator.Migrations.GetSortedMigrations();
@@ -155,7 +155,7 @@ public class LiteMigratorFactoryTests : BaseTest
 
     // Arrange
     long oldVer = 0;
-    var migrator = new Migrator(InMemoryDatabasePath, BaseNamespace, Assembly.GetExecutingAssembly());
+    using var migrator = new Migrator(InMemoryDatabasePath, BaseNamespace, assm);
 
     // Act
     var items = migrator.Migrations.GetSortedMigrations();

--- a/source/LiteMigrator.Tests/Specs/FactoryTests.cs
+++ b/source/LiteMigrator.Tests/Specs/FactoryTests.cs
@@ -7,7 +7,6 @@
  */
 
 using System.Reflection;
-using LiteMigrator;
 
 namespace LiteMigrator.SystemTests.Specs;
 
@@ -20,10 +19,14 @@ public class LiteMigratorFactoryTests : BaseTest
   private const long ScriptRevision = 201909150000;
 
   [TestMethod]
-  public void GetMigrationScriptByNameTest()
+  [DataRow(false)]
+  [DataRow(true)]
+  public void GetMigrationScriptByNameTest(bool useExecutingAssm)
   {
+    Assembly? assm = useExecutingAssm ? Assembly.GetExecutingAssembly() : null;
+
     // Arrange
-    var migrator = new Migrator(InMemoryDatabasePath, BaseNamespace, Assembly.GetExecutingAssembly());
+    var migrator = new Migrator(InMemoryDatabasePath, BaseNamespace, assm);
 
     // Act
     string ns = migrator.Migrations.GetResourceNamed(ScriptName);
@@ -36,9 +39,13 @@ public class LiteMigratorFactoryTests : BaseTest
   }
 
   [TestMethod]
-  public void GetMigrationScriptTest()
+  [DataRow(false)]
+  [DataRow(true)]
+  public void GetMigrationScriptTest(bool useExecutingAssm)
   {
-    var migrator = new Migrator(InMemoryDatabasePath, BaseNamespace, Assembly.GetExecutingAssembly());
+    Assembly? assm = useExecutingAssm ? Assembly.GetExecutingAssembly() : null;
+
+    var migrator = new Migrator(InMemoryDatabasePath, BaseNamespace, assm);
 
     // Sample: "MyProject.Client.Business.Migrations.201909150000-BaseDDL.sql"
     bool success = migrator.Migrations.GetMigrationScriptByName(ScriptFullName, out string? data);
@@ -49,8 +56,12 @@ public class LiteMigratorFactoryTests : BaseTest
   }
 
   [TestMethod]
-  public void GetMigrationScriptVerionTest()
+  [DataRow(false)]
+  [DataRow(true)]
+  public void GetMigrationScriptVerionTest(bool useExecutingAssm)
   {
+    Assembly? assm = useExecutingAssm ? Assembly.GetExecutingAssembly() : null;
+
     var migrator = new Migrator(InMemoryDatabasePath, BaseNamespace, Assembly.GetExecutingAssembly());
 
     var results = migrator.Migrations.GetMigrationScriptByVersion(ScriptRevision, out string? sql);
@@ -62,8 +73,12 @@ public class LiteMigratorFactoryTests : BaseTest
   }
 
   [TestMethod]
-  public void GetResourceNamedTest()
+  [DataRow(false)]
+  [DataRow(true)]
+  public void GetResourceNamedTest(bool useExecutingAssm)
   {
+    Assembly? assm = useExecutingAssm ? Assembly.GetExecutingAssembly() : null;
+
     // Arrange
     var migrator = new Migrator(InMemoryDatabasePath, BaseNamespace, Assembly.GetExecutingAssembly());
 
@@ -76,8 +91,12 @@ public class LiteMigratorFactoryTests : BaseTest
   }
 
   [TestMethod]
-  public void GetResourcesTests()
+  [DataRow(false)]
+  [DataRow(true)]
+  public void GetResourcesTests(bool useExecutingAssm)
   {
+    Assembly? assm = useExecutingAssm ? Assembly.GetExecutingAssembly() : null;
+
     // Arrange
     var migrator = new Migrator(InMemoryDatabasePath, BaseNamespace, Assembly.GetExecutingAssembly());
 
@@ -96,8 +115,12 @@ public class LiteMigratorFactoryTests : BaseTest
   }
 
   [TestMethod]
-  public void GetSortedMigrationsTest()
+  [DataRow(false)]
+  [DataRow(true)]
+  public void GetSortedMigrationsTest(bool useExecutingAssm)
   {
+    Assembly? assm = useExecutingAssm ? Assembly.GetExecutingAssembly() : null;
+
     // Arrange
     long oldVer = 0;
     var migrator = new Migrator(InMemoryDatabasePath, BaseNamespace, Assembly.GetExecutingAssembly());
@@ -124,8 +147,12 @@ public class LiteMigratorFactoryTests : BaseTest
   }
 
   [TestMethod]
-  public void ValidateMigrationNamingConventions()
+  [DataRow(false)]
+  [DataRow(true)]
+  public void ValidateMigrationNamingConventions(bool useExecutingAssm)
   {
+    Assembly? assm = useExecutingAssm ? Assembly.GetExecutingAssembly() : null;
+
     // Arrange
     long oldVer = 0;
     var migrator = new Migrator(InMemoryDatabasePath, BaseNamespace, Assembly.GetExecutingAssembly());

--- a/source/LiteMigrator.Tests/Specs/MigrateInFileTests.cs
+++ b/source/LiteMigrator.Tests/Specs/MigrateInFileTests.cs
@@ -40,11 +40,15 @@ public class MigratorInFileTests : BaseTest
   /// </summary>
   /// <returns>Task.</returns>
   [TestMethod]
-  public async Task InstallMigrationsTestAsync()
+  [DataRow(false)]
+  [DataRow(true)]
+  public async Task InstallMigrationsTestAsync(bool useExecutingAssm)
   {
+    Assembly? assm = useExecutingAssm ? Assembly.GetExecutingAssembly() : null;
+
     DeleteDatabase();
 
-    var mig = new Migrator(TempDatabasePath, _baseNamespace, Assembly.GetExecutingAssembly());
+    var mig = new Migrator(TempDatabasePath, _baseNamespace, assm);
 
     var allMigs = mig.Migrations.GetSortedMigrations();
     var missing = await mig.GetMissingMigrationsAsync();
@@ -65,8 +69,12 @@ public class MigratorInFileTests : BaseTest
   /// <summary>Gets list of migrations not applied yet.</summary>
   /// <returns>Task.</returns>
   [TestMethod]
-  public async Task NotAllMigrationsAreInstalledTestAsync()
+  [DataRow(false)]
+  [DataRow(true)]
+  public async Task NotAllMigrationsAreInstalledTestAsync(bool useExecutingAssm)
   {
+    Assembly? assm = useExecutingAssm ? Assembly.GetExecutingAssembly() : null;
+
     // Get not installed scripts.
     // returns sorted list of IMigration with namespace path to resource
     ClearVersionInfo();

--- a/source/LiteMigrator.Tests/Specs/MigrationInMemoryTests.cs
+++ b/source/LiteMigrator.Tests/Specs/MigrationInMemoryTests.cs
@@ -17,41 +17,30 @@ public sealed class MigrationInMemoryTests : BaseTest
   private const string ScriptNamespace = "LiteMigrator.SystemTests.TestData.Scripts";
 
   [TestMethod]
-  public async Task GetMigrationScriptsNoAssemblyTestAsync()
-  {
-    // Initializes and performs migration.
-    var migrator = new Migrator(InMemoryDatabasePath, ScriptNamespace);
-
-    // Find available migration scripts and those not installed
-    var allMigrations = migrator.Migrations.GetSortedMigrations();
-    var missing = await migrator.GetMissingMigrationsAsync();
-
-    Assert.AreEqual(2, allMigrations.Count);
-    Assert.IsNotNull(missing);
-    Assert.AreEqual(allMigrations.Count, missing.Count);
-  }
-
-  [TestMethod]
-  public async Task GetMigrationScriptsTestAsync()
-  {
-    // Initializes and performs migration.
-    var migrator = new Migrator(InMemoryDatabasePath, ScriptNamespace, Assembly.GetExecutingAssembly());
-
-    // Find available migration scripts and those not installed
-    var allMigrations = migrator.Migrations.GetSortedMigrations();
-    var missing = await migrator.GetMissingMigrationsAsync();
-
-    Assert.AreEqual(2, allMigrations.Count);
-    Assert.IsNotNull(missing);
-    Assert.AreEqual(allMigrations.Count, missing.Count);
-  }
-
-  [TestMethod]
-  [DataRow(true)]
   [DataRow(false)]
+  [DataRow(true)]
+  public async Task GetMigrationScriptsTestAsync(bool useExecutingAssm)
+  {
+    Assembly? assm = useExecutingAssm ? Assembly.GetExecutingAssembly() : null;
+
+    // Initializes and performs migration.
+    var migrator = new Migrator(InMemoryDatabasePath, ScriptNamespace, assm);
+
+    // Find available migration scripts and those not installed
+    var allMigrations = migrator.Migrations.GetSortedMigrations();
+    var missing = await migrator.GetMissingMigrationsAsync();
+
+    Assert.AreEqual(2, allMigrations.Count);
+    Assert.IsNotNull(missing);
+    Assert.AreEqual(allMigrations.Count, missing.Count);
+  }
+
+  [TestMethod]
+  [DataRow(false)]
+  [DataRow(true)]
   public async Task InstallMigrationsAsync(bool useExecutingAssm)
   {
-    Assembly? assm = useExecutingAssm  ? Assembly.GetExecutingAssembly() : null;
+    Assembly? assm = useExecutingAssm ? Assembly.GetExecutingAssembly() : null;
 
     using (var migrator = new Migrator(InMemoryDatabasePath, ScriptNamespace, assm))
     {
@@ -65,17 +54,5 @@ public sealed class MigrationInMemoryTests : BaseTest
       Assert.IsTrue(isSuccess, migrator.LastError);
       Assert.AreEqual(0, missing.Count);
     }
-  }
-
-  [TestCleanup]
-  public void TestCleanup()
-  {
-    // This method is called after each test method.
-  }
-
-  [TestInitialize]
-  public void TestInit()
-  {
-    // This method is called before each test method.
   }
 }

--- a/source/LiteMigrator/Factory/MigrationFactory.cs
+++ b/source/LiteMigrator/Factory/MigrationFactory.cs
@@ -194,18 +194,12 @@ public class MigrationFactory
   /// <remarks>Rename to, GetMigrations().</remarks>
   public SortedDictionary<long, IMigration> GetSortedMigrations()
   {
+    // TODO (2025-01-01: Should just exit if BaseAssembly is null. Could mislead if called from this assembly.
     var assembly = BaseAssembly is not null ? BaseAssembly : Assembly.GetCallingAssembly();
 
     var resources = assembly.GetManifestResourceNames();
     var items = resources
       .Where(name => name.StartsWith(BaseNamespace) && name.EndsWith(".sql"));
-
-    /*
-    var assembly = BaseAssembly; //// Assembly.GetExecutingAssembly();
-    var items = BaseAssembly
-      .GetManifestResourceNames()
-      .Where(name => name.StartsWith(BaseNamespace) && name.EndsWith(".sql"));
-    */
 
     // TODO: Need to check if error and report why
     // I.E.

--- a/source/LiteMigrator/Factory/MigrationFactory.cs
+++ b/source/LiteMigrator/Factory/MigrationFactory.cs
@@ -3,7 +3,7 @@
  * Author:  Damian Suess
  * File:    MigrationFactory.cs
  * Description:
- *
+ *  Migration script factory.
  */
 
 using System;
@@ -17,13 +17,10 @@ namespace LiteMigrator.Factory;
 
 public class MigrationFactory
 {
-  //// private string _baseAssemblyFile;
-
   public MigrationFactory()
   {
-    BaseNamespace = GetType().Namespace;
+    BaseNamespace = GetType().Namespace; // Default should be null.
     BaseAssembly = null;
-    //// BaseAssemblyFile = string.Empty;
   }
 
   public MigrationFactory(string baseNamespace, Assembly baseAssembly)
@@ -32,41 +29,10 @@ public class MigrationFactory
     BaseNamespace = baseNamespace;
   }
 
+  /// <summary>Gets or sets the Assembly containing our script files.</summary>
   public Assembly BaseAssembly { get; set; }
 
-  /*
-  public MigrationFactory(string baseNamespace, string baseAssemblyFile = "")
-  {
-    BaseNamespace = baseNamespace;
-    BaseAssemblyFile = baseAssemblyFile;
-  }
-
-  public Assembly BaseAssembly
-  {
-    get
-    {
-      Assembly assm;
-
-      try
-      {
-        if (!string.IsNullOrEmpty(BaseAssemblyFile))
-          assm = Assembly.LoadFile(BaseAssemblyFile);
-        else
-          assm = Assembly.GetExecutingAssembly();
-      }
-      catch
-      {
-        System.Console.WriteLine($"Error loading assembly from file, '{BaseAssemblyFile}'");
-        assm = Assembly.GetExecutingAssembly();
-      }
-
-      return assm;
-    }
-  }
-
-  public string BaseAssemblyFile { get; set; }
-  */
-
+  /// <summary>Gets or sets the assembly's resource path where scripts are located.</summary>
   public string BaseNamespace { get; set; }
 
   /// <summary>Get migration script data using name search.</summary>

--- a/source/LiteMigrator/Migrator.cs
+++ b/source/LiteMigrator/Migrator.cs
@@ -37,7 +37,7 @@ public partial class Migrator : IDisposable
   ///   Assumes the current namespace, and using generic SQLite.
   /// </summary>
   public Migrator()
-    : this(InMemoryDatabase, string.Empty, null)
+    : this(InMemoryDatabase, string.Empty, Assembly.GetCallingAssembly())
   {
     // Set to current namespace, it's a something
     // TODO (2025-01-01): Validate if we should use "" or GetType().Namespace
@@ -70,17 +70,19 @@ public partial class Migrator : IDisposable
   /// </summary>
   /// <param name="databasePath">Path to the SQLite database.</param>
   /// <param name="baseNamespace">Namespace to scripts.</param>
-  /// <param name="databaseType">Type of database connection.</param>
   /// <param name="baseAssembly">Migration's base assembly name.</param>
-  public Migrator(string databasePath, string baseNamespace, Assembly baseAssembly = null)
+  public Migrator(string databasePath, string baseNamespace, Assembly baseAssembly)
   {
     ////RevisionTable = nameof(VersionInfo);  // FUTURE
     // Set to current namespace, it's a something
     DatabasePath = databasePath;
 
+    // Attempt to get who called us
+    baseAssembly ??= Assembly.GetCallingAssembly();
+
     Migrations = new()
     {
-      BaseAssembly = baseAssembly,  // Consider using if null, Assembly.GetCallingAssembly()
+      BaseAssembly = baseAssembly,
       BaseNamespace = baseNamespace,
     };
 

--- a/source/LiteMigrator/Migrator.cs
+++ b/source/LiteMigrator/Migrator.cs
@@ -50,7 +50,7 @@ public partial class Migrator : IDisposable
   /// </summary>
   /// <param name="databasePath">Path to database.</param>
   public Migrator(string databasePath)
-    : this(databasePath, string.Empty, null)
+    : this(databasePath, string.Empty, Assembly.GetCallingAssembly())
   {
   }
 
@@ -61,7 +61,7 @@ public partial class Migrator : IDisposable
   /// <param name="databasePath">Path to database.</param>
   /// <param name="baseNamespace">Assembly path to migration scripts.</param>
   public Migrator(string databasePath, string baseNamespace)
-    : this(databasePath, baseNamespace, null)
+    : this(databasePath, baseNamespace, Assembly.GetCallingAssembly())
   {
   }
 
@@ -78,12 +78,9 @@ public partial class Migrator : IDisposable
     // Set to current namespace, it's a something
     DatabasePath = databasePath;
 
-    // Create version info table here
-    // Initialize().Wait();
     Migrations = new()
     {
-      // BaseAssemblyFile = baseAssembly is null ? string.Empty : baseAssembly.Location,
-      BaseAssembly = baseAssembly,
+      BaseAssembly = baseAssembly,  // Consider using if null, Assembly.GetCallingAssembly()
       BaseNamespace = baseNamespace,
     };
 
@@ -110,6 +107,7 @@ public partial class Migrator : IDisposable
     if (!Connect(DatabasePath))
       System.Diagnostics.Debug.WriteLine("Failed to create DB");
 
+    // Create version info table here
     // The next operation may begin before this is finished being created
     VersionInitialize();
 


### PR DESCRIPTION
## Details

When an Assembly containing the script files is not provided in the constructor, attempt to find it via using `Assembly.GetCallingAssembly()`. Otherwise, `GetExecutingAssembly()` will return "LiteMigrator.dll"

#28 